### PR TITLE
Remove white margins from LightRays background

### DIFF
--- a/portfolio/src/components/custom/LightRays.css
+++ b/portfolio/src/components/custom/LightRays.css
@@ -1,7 +1,8 @@
 .light-rays-container {
   width: 100%;
   height: 100%;
-  position: relative;
+  position: absolute;
+  inset: 0;
   pointer-events: none;
   z-index: 3;
   overflow: hidden;

--- a/portfolio/src/index.css
+++ b/portfolio/src/index.css
@@ -3,7 +3,7 @@
 @tailwind utilities;
 
 body {
-  @apply min-h-screen bg-white text-black dark:bg-gray-900 dark:text-white;
+  @apply m-0 min-h-screen bg-black text-white;
 }
 
 
@@ -11,7 +11,7 @@ body {
 @layer base {
   :root {
 
-    --background: 0 0% 100%;
+    --background: 0 0% 0%;
 
     --foreground: 0 0% 3.9%;
 
@@ -120,6 +120,6 @@ body {
     @apply border-border;
   }
   body {
-    @apply bg-background text-foreground;
+    @apply m-0 bg-background text-foreground;
   }
 }


### PR DESCRIPTION
## Summary
- ensure LightRays component covers its container
- remove default body margin and use black background

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688525e084248320a9aaa5baed0a6a05