### PR TITLE
Fix ScrollStack styling

### DIFF
--- a/portfolio/src/components/custom/ScrollStack.jsx
+++ b/portfolio/src/components/custom/ScrollStack.jsx
@@ -2,8 +2,10 @@ import { useLayoutEffect, useRef, useCallback } from "react";
 import Lenis from "lenis";
 import "./ScrollStack.css";
 
-export const ScrollStackItem = ({ children, itemClassName = "" }) => (
-  <div className={`scroll-stack-card ${itemClassName}`.trim()}>{children}</div>
+export const ScrollStackItem = ({ children, className = "", itemClassName }) => (
+  <div className={`scroll-stack-card ${className || itemClassName || ""}`.trim()}>
+    {children}
+  </div>
 );
 
 const ScrollStack = ({


### PR DESCRIPTION
## Summary
- allow `ScrollStackItem` to accept `className`

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68863c874bb08320979fa14240884470