### PR TITLE
Fix scrollStack overscroll behavior

### DIFF
--- a/portfolio/src/components/custom/ScrollStack.css
+++ b/portfolio/src/components/custom/ScrollStack.css
@@ -4,7 +4,8 @@
   height: 100vh;
   overflow-y: auto;
   overflow-x: visible;
-  overscroll-behavior: contain;
+  /* Allow scroll events to propagate when the stack reaches its bounds */
+  overscroll-behavior: auto;
   -webkit-overflow-scrolling: touch;
   scroll-behavior: smooth;
   -webkit-transform: translateZ(0);


### PR DESCRIPTION
## Summary
- allow wheel/touch events to bubble out of ScrollStack

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688698878ee48320971a88ff8a7ee666