### PR TITLE
Fix PixelCard responsiveness

### DIFF
--- a/portfolio/src/components/custom/PixelCard.css
+++ b/portfolio/src/components/custom/PixelCard.css
@@ -5,13 +5,14 @@
 }
 
 .pixel-card {
-  height: 400px;
-  width: 300px;
+  width: 100%;
+  max-width: 300px;
+  max-height: 400px;
+  aspect-ratio: 4 / 5;
   position: relative;
   overflow: hidden;
   display: grid;
   place-items: center;
-  aspect-ratio: 4 / 5;
   border: 1px solid #27272a;
   border-radius: 25px;
   isolation: isolate;


### PR DESCRIPTION
## Summary
- let `.pixel-card` adapt to container size so that it's not clipped on small screens

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6886b9575a5c8320ba711501a2df3844