### PR TITLE
Fix PixelCard alignment

### DIFF
--- a/portfolio/src/App.jsx
+++ b/portfolio/src/App.jsx
@@ -20,7 +20,7 @@ export default function App() {
       />
       <PixelCard
         variant="pink"
-        className="cursor-target absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2"
+        className="cursor-target fixed left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2"
       >
         <div className="absolute inset-0 flex items-center justify-center text-white">
           <h2 className="text-xl font-bold">Zay168 : usage</h2>


### PR DESCRIPTION
## Summary
- center PixelCard in the viewport so it isn't cropped at the top

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6886c8c0c85c8320865d2f8d027fdce6